### PR TITLE
Fix README: correct environment file extension to .yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git clone "https:github.com/matmulmiller/TRANSONIC"
 For best practices, it is best to create a new python virtual environment to contain the package dependencies. You can do this by running 
 
 ```
-conda env create -f environment.yaml
+conda env create -f environment.yml
 ```
 
 Please note that this step is necessary to have a working GUI for TRANSONIC.


### PR DESCRIPTION
The README file incorrectly suggests using `conda env create -f environment.yaml`. The correct file extension is `.yml`. This PR fixes the command to `conda env create -f environment.yml`.
