### PR TITLE
61 create docker image

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,1 +1,0 @@
-sudo docker image build --no-cache -t transonic ./docker/

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,1 @@
+sudo docker image build --no-cache -t transonic ./docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,13 @@ FROM continuumio/miniconda3
 
 RUN apt-get update
 RUN apt-get install sudo
+RUN apt-get install -y x11-apps
 RUN apt-get install 'ffmpeg'\
     'libsm6'\ 
     'libxext6'  -y
+RUN apt-get install -y libqt5gui5 && \
+    rm -rf /var/lib/apt/lists/*
+ENV QT_DEBUG_PLUGINS=1
 
 
 RUN git clone -b 61-create-docker-image "https://github.com/matmulmiller/TRANSONIC" /root/TRANSONIC

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM continuumio/miniconda3
+
+RUN apt-get update
+RUN apt-get install sudo
+RUN apt-get install 'ffmpeg'\
+    'libsm6'\ 
+    'libxext6'  -y
+
+
+RUN git clone -b 61-create-docker-image "https://github.com/matmulmiller/TRANSONIC" /root/TRANSONIC
+
+
+#RUN ~/miniconda3/bin/conda init bash
+RUN conda env create -f /root/TRANSONIC/environment.yml
+RUN conda init
+RUN echo "conda activate transonic_env" >> ~/.bashrc
+RUN echo "cd ~/TRANSONIC/" >> ~/.bashrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,6 @@ FROM continuumio/miniconda3
 
 RUN apt-get update
 RUN apt-get install sudo
-RUN apt-get install -y x11-apps
 RUN apt-get install 'ffmpeg'\
     'libsm6'\ 
     'libxext6'  -y

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,0 +1,1 @@
+sudo docker image build --no-cache -t transonic .

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,1 +1,2 @@
 sudo docker image build --no-cache -t transonic .
+sudo xhost +local:docker

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+TRANSONIC_PATH=~/spades/TRANSONIC
+
+sudo docker container run -ti -v ${TRANSONIC_PATH}/user_data:/root/TRANSONIC/user_data/ transonic

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -2,4 +2,4 @@
 
 TRANSONIC_PATH=~/spades/TRANSONIC
 
-sudo docker container run -ti -v ${TRANSONIC_PATH}/user_data:/root/TRANSONIC/user_data/ transonic
+sudo docker container run -ti -v ${TRANSONIC_PATH}/user_data:/root/TRANSONIC/user_data/ -v "${HOME}/.Xauthority":"/root/.Xauthority:ro" -e "DISPLAY=$DISPLAY" --network host transonic

--- a/environment.yml
+++ b/environment.yml
@@ -3,3 +3,9 @@ name: transonic_env
 dependencies:
   - python=3.12
   - pyqt
+  - pandas>=2.2
+  - matplotlib>=3.8
+  - pyyaml>=6.0
+  - numpy>=1.26
+  - scipy>=1.12
+  - scikit-learn>=1.3

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - numpy>=1.26
   - scipy>=1.12
   - scikit-learn>=1.3
+  - tqdm

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-#sudo docker container run -ti -v /root/TRANSONIC/user_data/:./user_data/ transonic
-
-sudo docker container run -ti -v ./user_data:/root/TRANSONIC/user_data/ transonic

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-sudo docker container run -ti --rm -v ./user_data/ -w /root/TRANSONIC/user_data/ transonic
+#sudo docker container run -ti -v /root/TRANSONIC/user_data/:./user_data/ transonic
+
+sudo docker container run -ti -v ./user_data:/root/TRANSONIC/user_data/ transonic

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo docker container run -ti --rm -v ./user_data/ -w /root/TRANSONIC/user_data/ transonic

--- a/src/transonic/Windows/App.ui
+++ b/src/transonic/Windows/App.ui
@@ -55,7 +55,7 @@ File</string>
 Results</string>
     </property>
    </widget>
-<<<<<<< HEAD
+HEAD
    <widget class="QLabel" name="completion_label">
     <property name="geometry">
      <rect>

--- a/src/transonic/main.py
+++ b/src/transonic/main.py
@@ -63,7 +63,7 @@ def cli_main() -> int:
     summary_df = solve(doe, config_data, results_dir, model_class)
     
     # Save results to specified results folder in config file
-    summary_df.to_csv(path.join(results_folder, 'eval_outputs.csv'))
+    summary_df.to_csv(path.join(results_dir, 'eval_outputs.csv'))
 
     return 0
     


### PR DESCRIPTION
Initial implementation of the docker image use-case. The command line interface should work, at least in its current implementation, on any os as long as you have docker installed. Inside of the docker folder, there are scripts for building and running the docker image. For the gui to work, x11 forwarding must be allowed to the local host, and the second and last command in the build_docker.sh script allows docker to forward windows to the local host. This is necessary for forwarding the window from the gui to be displayed. WIth this implementation the gui works on linux. A lot of warnings pop up so future updates may want to suppress those. Also, along with this I did update the environment.yml to include all of the necessary packages to run the application. This appears to be necessary to generate the environment in the docker image. If this breaks the install process somehow (it's unlikely it will), we can revise the strategy.